### PR TITLE
Security considerations hardening

### DIFF
--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -139,12 +139,6 @@ encapsulation key. The ECDH share is serialized value of the uncompressed ECDH p
 representation as defined in {{Section 4.3.8.2 of !RFC9846}}. The size of the
 client share is 1665 bytes (97 bytes for the secp384r1 part and 1568 for ML-KEM).
 
-Note: During ML-KEM encapsulation, a value `m` drawn from a random bit generator is encrypted
-(see {{NIST-FIPS-203}}, Algorithms 17 and 20); the client, which holds the decapsulation key,
-then recovers `m` exactly during decapsulation (see {{NIST-FIPS-203}}, Algorithm 18).
-Consequently, any information `m` carries about the generator's other outputs is also
-exposed to the client.
-
 ## Server share
 
 When the X25519MLKEM768 group is negotiated, the server's key exchange
@@ -233,12 +227,17 @@ by remote attackers.
 All groups defined in this document use and generate fixed-length public keys, ciphertexts,
 and shared secrets, which complies with the requirements described in {{Section 6 of hybrid}}.
 
+During ML-KEM encapsulation, encapsulation randomness `m` is drawn from a random bit generator and encrypted
+(see {{NIST-FIPS-203}}, Algorithms 17 and 20); the client, which holds the decapsulation key, then recovers `m`
+exactly during decapsulation (see {{NIST-FIPS-203}}, Algorithm 18). Consequently, any information `m` carries
+about the generator's other outputs is also exposed to the client.
+
 The disclosure of the output(s) of an insecure random number generator (RNG) when used in TLS can
 be used in an attack to compromise the state of the insecure RNG itself as described in {{DUALECTLS}}.
-The `m` value in ML-KEM is an additional place where RNG output is disclosed to an active attacker. Because
-the `m` value in ML-KEM is randomly generated, encrypted and transmitted to the client, implementers should
-follow the RBG guidance in {{NIST-FIPS-203}} and the random number generation guidance in {{Section C.1 of RFC9846}}.
-Implementers can choose to implement mechanisms from {{RFC8937}} for additional protection across sessions.
+The encapsulation randomness `m` in ML-KEM is an additional place where RNG output is disclosed to an active attacker.
+Implementers should follow the RBG guidance in {{NIST-FIPS-203}} and the random number generation guidance in
+{{Section C.1 of RFC9846}}. Implementers can choose to implement mechanisms from {{RFC8937}} for additional protection
+across sessions.
 
 In contrast, the ECDH ephemeral scalars taken from the RNG are never directly disclosed to the peer. However,
 any passive observer with access to a cryptographically relevant quantum computer (CRQC) can recover the scalar,

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -47,6 +47,7 @@ author:
 
 normative:
   RFC7748:
+  RFC9846:
   hybrid: I-D.ietf-tls-hybrid-design
   NIST-FIPS-186: DOI.10.6028/NIST.FIPS.186-5
   NIST-FIPS-203: DOI.10.6028/NIST.FIPS.203
@@ -59,7 +60,6 @@ informative:
   RFC9847:
   RFC5869:
   RFC8937:
-  RFC9846:
   DUALECTLS:
     title: "On the Practical Exploitability of Dual EC in TLS Implementations"
     target: <https://www.usenix.org/system/files/conference/usenixsecurity14/sec14-paper-checkoway.pdf>
@@ -314,6 +314,12 @@ Experimental code points for pre-standard versions of Kyber768 were added to the
 --- back
 
 # Change log
+
+* draft-ietf-tls-ecdhe-mlkem-06:
+  * References: RFC 9846 moves from informative to normative.
+
+* draft-ietf-tls-ecdhe-mlkem-05:
+  * Sets RECOMMENDED=Y on X2519-MLKEM768
 
 * draft-ietf-tls-ecdhe-mlkem-04:
   * Status: Sets document category to Standards Track

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -226,8 +226,9 @@ The same security considerations as those described in {{hybrid}} apply to the a
 The security analysis relies crucially on the TLS 1.3 message transcript, and one cannot assume a similar
 hybridisation is secure in other protocols.
 
-{{NIST-SP-800-227}} includes guidelines and requirements for implementations on using KEMs securely. Implementers are encouraged to use implementations resistant to side-channel attacks,
-especially those that can be applied by remote attackers.
+{{NIST-SP-800-227}} includes guidelines and requirements for implementations on using KEMs securely. Implementers
+are encouraged to use implementations resistant to side-channel attacks, especially those that can be applied
+by remote attackers.
 
 All groups defined in this document use and generate fixed-length public keys, ciphertexts,
 and shared secrets, which complies with the requirements described in {{Section 6 of hybrid}}.
@@ -239,9 +240,11 @@ the `m` value in ML-KEM is randomly generated, encrypted and transmitted to the 
 follow the RBG guidance in {{NIST-FIPS-203}} and the random number generation guidance in {{Section C.1 of RFC9846}}.
 Implementers can choose to implement mechanisms from {{RFC8937}} for additional protection across sessions.
 
-In contrast, the ECDH ephemeral scalars are never directly disclosed. Ephemeral scalars should nevertheless be
-generated using a cryptographically secure RNG: for secp256r1 and secp384r1 as required by {{NIST-SP-800-56A}},
-and for X25519 as described in {{RFC7748}}; the guidance in {{Section C.1 of RFC9846}} applies here as well.
+In contrast, the ECDH ephemeral scalars taken from the RNG are never directly disclosed to the peer. However,
+any passive observer with access to a cryptographically relevant quantum computer (CRQC) can recover the scalar,
+which is derived directly from RNG output. Regardless, ephemeral scalars should always be generated using a
+cryptographically secure RNG: for secp256r1 and secp384r1 as required by {{NIST-SP-800-56A}}, and for X25519
+as described in {{RFC7748}}; the guidance in {{Section C.1 of RFC9846}} applies here as well.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -232,12 +232,16 @@ especially those that can be applied by remote attackers.
 All groups defined in this document use and generate fixed-length public keys, ciphertexts,
 and shared secrets, which complies with the requirements described in {{Section 6 of hybrid}}.
 
-The disclosure of the output(s) of an insecure random number generator (RNG) when used in TLS can be used in an
-attack to compromise the state of the insecure RNG itself as described in {{DUALECTLS}}. The `m` value in ML-KEM is an
-additional place where raw RNG output is disclosed to an active attacker. Because the `m` value in ML-KEM is randomly
-generated and transmitted to the client, it is important to follow the RBG guidance in {{NIST-FIPS-203}} and the random number
-generation guidance in {{RFC9846}}. Implementers MAY choose to implement mechanisms from {{RFC8937}} for additional
-protection across sessions.
+The disclosure of the output(s) of an insecure random number generator (RNG) when used in TLS can
+be used in an attack to compromise the state of the insecure RNG itself as described in {{DUALECTLS}}.
+The `m` value in ML-KEM is an additional place where RNG output is disclosed to an active attacker. Because
+the `m` value in ML-KEM is randomly generated, encrypted and transmitted to the client, implementers MUST
+follow the RBG guidance in {{NIST-FIPS-203}} and the random number generation guidance in {{Section C.1 of RFC9846}}.
+Implementers MAY choose to implement mechanisms from {{RFC8937}} for additional protection across sessions.
+
+In contrast, the ECDH ephemeral scalars are never directly disclosed. Ephemeral scalars MUST nevertheless be
+generated using a cryptographically secure RNG: for secp256r1 and secp384r1 as required by {{NIST-SP-800-56A}},
+and for X25519 as described in {{RFC7748}}; the guidance in {{Section C.1 of RFC9846}} applies here as well.
 
 # IANA Considerations
 
@@ -317,6 +321,7 @@ Experimental code points for pre-standard versions of Kyber768 were added to the
 
 * draft-ietf-tls-ecdhe-mlkem-06:
   * References: RFC 9846 moves from informative to normative.
+  * Security Considerations: Clarify that, unlike the ML-KEM `m` value, ECDH ephemeral scalars are not directly disclosed, and add RBG requirements for scalar generation per SP 800-56A and RFC 9846 Appendix C.1.
 
 * draft-ietf-tls-ecdhe-mlkem-05:
   * Sets RECOMMENDED=Y on X2519-MLKEM768

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -130,13 +130,13 @@ reversed. This is due to historical reasons.
 When the SecP256r1MLKEM768 group is negotiated, the client's key_exchange value
 is the concatenation of the secp256r1 ephemeral share and ML-KEM-768 encapsulation key.
 The ECDHE share is the serialized value of the uncompressed ECDH point representation as
-defined  in {{Section 4.2.8.2 of !RFC8446}}. The size of the client share is 1249 bytes
+defined  in {{Section 4.2.8.2 of !RFC9846}}. The size of the client share is 1249 bytes
 (65 bytes for the secp256r1 part and 1184 bytes for ML-KEM).
 
 When the SecP384r1MLKEM1024 group is negotiated, the client's key_exchange value
 is the concatenation of the secp384r1 ephemeral share and the ML-KEM-1024
 encapsulation key. The ECDH share is serialized value of the uncompressed ECDH point
-represenation as defined in {{Section 4.2.8.2 of !RFC8446}}. The size of the
+represenation as defined in {{Section 4.2.8.2 of !RFC9846}}. The size of the
 client share is 1665 bytes (97 bytes for the secp384r1 part and 1568 for ML-KEM).
 
 Note: During ML-KEM encapsulation, a value `m` drawn from a random bit generator is encrypted
@@ -175,7 +175,7 @@ If ML-KEM decapsulation fails for any other reason, the connection MUST
 be aborted with an internal_error alert.
 
 For all groups, both client and server MUST process the ECDH part
-as described in {{Section 4.2.8.2 of !RFC8446}}, including all validity checks,
+as described in {{Section 4.2.8.2 of !RFC9846}}, including all validity checks,
 and abort with an illegal_parameter alert if it fails.
 
 ## Shared secret
@@ -187,18 +187,18 @@ shared secret and the X25519 shared secret. The shared secret is 64 bytes
 For SecP256r1MLKEM768, the shared secret is the concatenation of the
 ECDHE and ML-KEM shared secret. The ECDHE shared secret is the x-coordinate of the ECDH
 shared secret elliptic curve point represented as an octet string as
-defined in {{Section 7.4.2 of !RFC8446}}.
+defined in {{Section 7.4.2 of !RFC9846}}.
 The size of the shared secret is 64 bytes (32 bytes for each part).
 
 For SecP384r1MLKEM1024, the shared secret is the concatenation of the
 ECDHE and ML-KEM shared secret. The ECDHE shared secret is the x-coordinate of the ECDH
 shared secret elliptic curve point represented as an octet string as
-defined in {{Section 7.4.2 of !RFC8446}}.
+defined in {{Section 7.4.2 of !RFC9846}}.
 The size of the shared secret is 80 bytes (48 bytes for the ECDH part and
 32 bytes for the ML-KEM part).
 
 For all groups, both client and server MUST calculate the ECDH part of the
-shared secret as described in {{Section 7.4.2 of !RFC8446}}, including the
+shared secret as described in {{Section 7.4.2 of !RFC9846}}, including the
 all-zero shared secret check for X25519, and abort the connection with an
 illegal_parameter alert if it fails.
 

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -62,7 +62,7 @@ informative:
   RFC8937:
   DUALECTLS:
     title: "On the Practical Exploitability of Dual EC in TLS Implementations"
-    target: <https://www.usenix.org/system/files/conference/usenixsecurity14/sec14-paper-checkoway.pdf>
+    target: https://www.usenix.org/system/files/conference/usenixsecurity14/sec14-paper-checkoway.pdf
     date: 2014
 
 --- abstract

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -130,13 +130,13 @@ reversed. This is due to historical reasons.
 When the SecP256r1MLKEM768 group is negotiated, the client's key_exchange value
 is the concatenation of the secp256r1 ephemeral share and ML-KEM-768 encapsulation key.
 The ECDHE share is the serialized value of the uncompressed ECDH point representation as
-defined  in {{Section 4.2.8.2 of !RFC9846}}. The size of the client share is 1249 bytes
+defined  in {{Section 4.3.8.2 of !RFC9846}}. The size of the client share is 1249 bytes
 (65 bytes for the secp256r1 part and 1184 bytes for ML-KEM).
 
 When the SecP384r1MLKEM1024 group is negotiated, the client's key_exchange value
 is the concatenation of the secp384r1 ephemeral share and the ML-KEM-1024
 encapsulation key. The ECDH share is serialized value of the uncompressed ECDH point
-represenation as defined in {{Section 4.2.8.2 of !RFC9846}}. The size of the
+represenation as defined in {{Section 4.3.8.2 of !RFC9846}}. The size of the
 client share is 1665 bytes (97 bytes for the secp384r1 part and 1568 for ML-KEM).
 
 Note: During ML-KEM encapsulation, a value `m` drawn from a random bit generator is encrypted
@@ -175,7 +175,7 @@ If ML-KEM decapsulation fails for any other reason, the connection MUST
 be aborted with an internal_error alert.
 
 For all groups, both client and server MUST process the ECDH part
-as described in {{Section 4.2.8.2 of !RFC9846}}, including all validity checks,
+as described in {{Section 4.3.8.2 of !RFC9846}}, including all validity checks,
 and abort with an illegal_parameter alert if it fails.
 
 ## Shared secret

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -235,11 +235,11 @@ and shared secrets, which complies with the requirements described in {{Section 
 The disclosure of the output(s) of an insecure random number generator (RNG) when used in TLS can
 be used in an attack to compromise the state of the insecure RNG itself as described in {{DUALECTLS}}.
 The `m` value in ML-KEM is an additional place where RNG output is disclosed to an active attacker. Because
-the `m` value in ML-KEM is randomly generated, encrypted and transmitted to the client, implementers MUST
+the `m` value in ML-KEM is randomly generated, encrypted and transmitted to the client, implementers should
 follow the RBG guidance in {{NIST-FIPS-203}} and the random number generation guidance in {{Section C.1 of RFC9846}}.
-Implementers MAY choose to implement mechanisms from {{RFC8937}} for additional protection across sessions.
+Implementers can choose to implement mechanisms from {{RFC8937}} for additional protection across sessions.
 
-In contrast, the ECDH ephemeral scalars are never directly disclosed. Ephemeral scalars MUST nevertheless be
+In contrast, the ECDH ephemeral scalars are never directly disclosed. Ephemeral scalars should nevertheless be
 generated using a cryptographically secure RNG: for secp256r1 and secp384r1 as required by {{NIST-SP-800-56A}},
 and for X25519 as described in {{RFC7748}}; the guidance in {{Section C.1 of RFC9846}} applies here as well.
 

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -58,6 +58,12 @@ informative:
   RFC9794:
   RFC9847:
   RFC5869:
+  RFC8937:
+  RFC9846:
+  DUALECTLS:
+    title: "On the Practical Exploitability of Dual EC in TLS Implementations"
+    target: <https://www.usenix.org/system/files/conference/usenixsecurity14/sec14-paper-checkoway.pdf>
+    date: 2014
 
 --- abstract
 
@@ -132,6 +138,12 @@ is the concatenation of the secp384r1 ephemeral share and the ML-KEM-1024
 encapsulation key. The ECDH share is serialized value of the uncompressed ECDH point
 represenation as defined in {{Section 4.2.8.2 of !RFC8446}}. The size of the
 client share is 1665 bytes (97 bytes for the secp384r1 part and 1568 for ML-KEM).
+
+Note: During ML-KEM encapsulation, a value `m` drawn from a random bit generator is encrypted
+(see {{NIST-FIPS-203}}, algorithm 17 and 20); the client, which holds the decapsulation key,
+then recovers `m` exactly during decapsulation (see {{NIST-FIPS-203}}, algorithm 18).
+Consequently, any information `m` carries about the generator's other outputs is also
+exposed to the client.
 
 ## Server share
 
@@ -219,6 +231,13 @@ especially those that can be applied by remote attackers.
 
 All groups defined in this document use and generate fixed-length public keys, ciphertexts,
 and shared secrets, which complies with the requirements described in {{Section 6 of hybrid}}.
+
+The disclosure of the output(s) of an insecure random number generator (RNG) when used in TLS can be used in an
+attack to compromise the state of the insecure RNG itself as described in {{DUALECTLS}}. The `m` value in ML-KEM is an
+additional place where raw RNG output is disclosed to an active attacker. Because the `m` value in ML-KEM is randomly
+generated and transmitted to the client, it is important to follow the RBG guidance in {{NIST-FIPS-203}} and the random number
+generation guidance in {{RFC9846}}. Implementers MAY choose to implement mechanisms from {{RFC8937}} for additional
+protection across sessions.
 
 # IANA Considerations
 

--- a/draft-ietf-tls-ecdhe-mlkem.md
+++ b/draft-ietf-tls-ecdhe-mlkem.md
@@ -76,8 +76,8 @@ SecP256r1MLKEM768, and SecP384r1MLKEM1024 - that combine the post-quantum ML-KEM
 
 # Introduction
 
-ML-KEM is a key encapsulation mechanism (KEM) defined in the {{NIST-FIPS-203}}. It is designed to
-withstand cryptanalytic attacks from quantum computers.
+ML-KEM is a key encapsulation mechanism (KEM) defined in {{NIST-FIPS-203}}. It is designed to withstand
+cryptanalytic attacks from quantum computers.
 
 The {{hybrid}} document defines a framework for combining traditional key exchanges with next-generation key
 exchange in TLS 1.3. The goal of this approach is to provide security against both classical and quantum
@@ -136,12 +136,12 @@ defined  in {{Section 4.3.8.2 of !RFC9846}}. The size of the client share is 124
 When the SecP384r1MLKEM1024 group is negotiated, the client's key_exchange value
 is the concatenation of the secp384r1 ephemeral share and the ML-KEM-1024
 encapsulation key. The ECDH share is serialized value of the uncompressed ECDH point
-represenation as defined in {{Section 4.3.8.2 of !RFC9846}}. The size of the
+representation as defined in {{Section 4.3.8.2 of !RFC9846}}. The size of the
 client share is 1665 bytes (97 bytes for the secp384r1 part and 1568 for ML-KEM).
 
 Note: During ML-KEM encapsulation, a value `m` drawn from a random bit generator is encrypted
-(see {{NIST-FIPS-203}}, algorithm 17 and 20); the client, which holds the decapsulation key,
-then recovers `m` exactly during decapsulation (see {{NIST-FIPS-203}}, algorithm 18).
+(see {{NIST-FIPS-203}}, Algorithms 17 and 20); the client, which holds the decapsulation key,
+then recovers `m` exactly during decapsulation (see {{NIST-FIPS-203}}, Algorithm 18).
 Consequently, any information `m` carries about the generator's other outputs is also
 exposed to the client.
 
@@ -163,7 +163,7 @@ value is the concatenation of the server's ephemeral secp384r1 share
 encoded in the same way as the client share and an ML-KEM ciphertext returned
 from encapsulation to the client's encapsulation key. The size of the server
 share is 1665 bytes (1568 bytes for the ML-KEM part and 97 bytes for
-secp384r1)
+secp384r1).
 
 For all groups, the server MUST perform the encapsulation key check
 described in Section 7.2 of {{NIST-FIPS-203}} on the client's encapsulation
@@ -218,7 +218,7 @@ in SecP256r1MLKEM768 and SecP384r1MLKEM1024. This means that for SecP256r1MLKEM7
 the ECDH implementation must be certified whereas the ML-KEM implementation does not require certification. In
 contrast, for X25519MLKEM768, the ML-KEM implementation must be certified.
 
-* **SP800-227 compliance**. The NIST Special Publication 800-227 {{NIST-SP-800-227}} provides general guidance on the design and use of key-encapsulation mechanisms, including hybrid constructions. The key agreements defined in this document follow the principles described in Section 4.6 of {{NIST-SP-800-227}}, which discusses the combination of post-quantum and classical key-establishment schemes and the use of approved key combiners. In particular, the shared-secret concatenation and HKDF-based derivation used by the TLS 1.3 are consistent with the composite-KEM constructions and key-combiner recommendations outlined in Sections 4.6.1 and 4.6.2 of {{NIST-SP-800-227}}. Section 4.6.3 of {{NIST-SP-800-227}} further provides relevant security considerations for hybrid KEM designs underlying the approach used in this document.
+* **SP800-227 compliance**. The NIST Special Publication 800-227 {{NIST-SP-800-227}} provides general guidance on the design and use of key-encapsulation mechanisms, including hybrid constructions. The key agreements defined in this document follow the principles described in Section 4.6 of {{NIST-SP-800-227}}, which discusses the combination of post-quantum and classical key-establishment schemes and the use of approved key combiners. In particular, the shared-secret concatenation and HKDF-based derivation used by TLS 1.3 are consistent with the composite-KEM constructions and key-combiner recommendations outlined in Sections 4.6.1 and 4.6.2 of {{NIST-SP-800-227}}. Section 4.6.3 of {{NIST-SP-800-227}} further provides relevant security considerations for hybrid KEM designs underlying the approach used in this document.
 
 # Security Considerations
 
@@ -327,7 +327,7 @@ Experimental code points for pre-standard versions of Kyber768 were added to the
   * Security Considerations: Clarify that, unlike the ML-KEM `m` value, ECDH ephemeral scalars are not directly disclosed, and add RBG requirements for scalar generation per SP 800-56A and RFC 9846 Appendix C.1.
 
 * draft-ietf-tls-ecdhe-mlkem-05:
-  * Sets RECOMMENDED=Y on X2519-MLKEM768
+  * Sets RECOMMENDED=Y on X25519MLKEM768
 
 * draft-ietf-tls-ecdhe-mlkem-04:
   * Status: Sets document category to Standards Track


### PR DESCRIPTION
* Adds hardening of security considerations as per consensus call
  https://mailarchive.ietf.org/arch/msg/tls/tPe7m_vpmDco43588yVW3JWrb8U/
* Improves formatting
* Moved RFC 9846 to normative
* Add text about RNG usage for X25519, Secp256/384 
